### PR TITLE
Swap xarray.open_rasterio for rioxarray.open_rasterio #62

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 23.3.0
     hooks:
     -   id: black
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v1.2.0
     hooks:
     -   id: mypy
         args: [--disallow-untyped-defs, --no-implicit-optional, --warn-unused-ignores, --warn-redundant-casts, --warn-unreachable]
@@ -13,7 +13,7 @@ repos:
         additional_dependencies: [types-requests, xarray]
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--profile, black]

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open("README.rst") as readme_file:
 requirements = [
     "rasterio",
     "xarray",
+    "rioxarray",
     "earthengine-api",
     "tqdm",
     "requests",

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -98,7 +98,7 @@ def test_to_xarray():
     collection = ee.ImageCollection(test_list)
     ds = collection.wx.to_xarray(region=region, scale=20, crs=crs, progress=False)
 
-    assert crs in ds.crs
+    assert crs == ds.rio.crs
     assert all(
         ds.time.values
         == [

--- a/wxee/image.py
+++ b/wxee/image.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import ee  # type: ignore
 import rasterio  # type: ignore
 import xarray as xr
-from urllib3.exceptions import ProtocolError  # type: ignore
+from urllib3.exceptions import ProtocolError
 
 from wxee import constants
 from wxee.accessors import wx_accessor

--- a/wxee/utils.py
+++ b/wxee/utils.py
@@ -11,10 +11,11 @@ import ee  # type: ignore
 import joblib  # type: ignore
 import rasterio  # type: ignore
 import requests
+import rioxarray  # type: ignore
 import xarray as xr
 from requests.adapters import HTTPAdapter
 from tqdm.auto import tqdm  # type: ignore
-from urllib3.util.retry import Retry  # type: ignore
+from urllib3.util.retry import Retry
 
 
 def Initialize(**kwargs: Any) -> None:
@@ -157,7 +158,7 @@ def _dataarray_from_file(file: str, masked: bool, nodata: int) -> xr.DataArray:
 
     The file name must follow the format "{dimension}.{coordinate}.{variable}.{extension}".
     """
-    da = xr.open_rasterio(file)
+    da = rioxarray.open_rasterio(file)
     dim, coord, var = _parse_filename(file)
 
     da = da.expand_dims({dim: [coord]}).rename(var).squeeze("band").drop_vars("band")

--- a/wxee/xarray.py
+++ b/wxee/xarray.py
@@ -65,14 +65,14 @@ class DatasetAccessor:
 
         >>> ds.wx.rgb(bands=["B8", "B4", "B3"], stretch=0.85, interactive=True, aspect=1.2)
         """
-        if bands:
+        if bands is not None:
             if len(bands) != 3:
                 raise ValueError(f"Bands must be a list with exactly 3 names.")
         else:
-            bands = list(self._obj.var())[:3]
+            bands = list(self._obj.var())[:3]  # type: ignore
 
             # Raise a different error if the bands were identified implicitly to avoid confusion
-            if len(bands) != 3:
+            if len(bands) != 3:  # type: ignore
                 raise ValueError(
                     f"The Dataset must contain at least 3 data variables for RGB plotting."
                 )


### PR DESCRIPTION
xarray just dropped the deprecated open_rasterio method (see #62), so this swaps in rioxarray.open_rasterio when calling to_xarray. This is a potentially breaking change because the two methods stored slightly different metadata in the resulting dataset (e.g. ds.crs must now be accessed through ds.rio.crs). More details on differences between the two methods can be found [here](https://corteva.github.io/rioxarray/stable/getting_started/getting_started.html).

In the process of getting pre-commit checks to pass, we also had to update all the outdated, broken hooks and make a few changes to get mypy passing.