### PR TITLE
Deprecate path parameter for saving to netcdf

### DIFF
--- a/wxee/collection.py
+++ b/wxee/collection.py
@@ -1,4 +1,5 @@
 import tempfile
+import warnings
 from typing import List, Optional
 
 import ee  # type: ignore
@@ -74,8 +75,6 @@ class ImageCollection:
 
         Parameters
         ----------
-        path : str, optional
-            The path to save the dataset to as a NetCDF. If none is given, the dataset will be stored in memory.
         region : ee.Geometry, optional
             The region to download the images within. If none is provided, the :code:`geometry` of the image collection
             will be used. If geometry varies between images in the collection, the region will encompass all images
@@ -115,7 +114,6 @@ class ImageCollection:
         >>> col.wx.to_xarray(scale=40000, crs="EPSG:5070", nodata=-9999)
         """
         with tempfile.TemporaryDirectory(prefix=constants.TMP_PREFIX) as tmp:
-
             files = self._obj.wx.to_tif(
                 out_dir=tmp,
                 region=region,
@@ -132,6 +130,11 @@ class ImageCollection:
             ds = _dataset_from_files(files, masked, nodata)
 
         if path:
+            msg = (
+                "The path argument is deprecated and will be removed in a future "
+                "release. Use the `xarray.Dataset.to_netcdf` method instead."
+            )
+            warnings.warn(category=DeprecationWarning, message=msg)
             ds.to_netcdf(path, mode="w")
 
         return ds

--- a/wxee/image.py
+++ b/wxee/image.py
@@ -41,8 +41,6 @@ class Image:
 
         Parameters
         ----------
-        path : str, optional
-            The path to save the dataset to as a NetCDF. If none is given, the dataset will be stored in memory.
         region : ee.Geometry, optional
             The region to download the image within. If none is provided, the :code:`geometry` of the image will be used.
         scale : int, optional
@@ -92,6 +90,11 @@ class Image:
             ds = _dataset_from_files(files, masked, nodata)
 
         if path:
+            msg = (
+                "The path argument is deprecated and will be removed in a future "
+                "release. Use the `xarray.Dataset.to_netcdf` method instead."
+            )
+            warnings.warn(category=DeprecationWarning, message=msg)
             ds.to_netcdf(path, mode="w")
 
         return ds


### PR DESCRIPTION
For simplicity, this deprecates the `path` parameter to the `to_xarray` methods. Instead, users can directly access the [to_netcdf](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.to_netcdf.html) method in `xarray`.