### PR TITLE
Simplify dev dependencies

### DIFF
--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -1,16 +1,5 @@
 name: tests-coverage
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-    paths-ignore:
-      - '.pre-commit-config.yaml'
-      - 'docs/**'
-      - '**.md'
-      - '**.rst'
-
 jobs:
   build:
 

--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -1,5 +1,7 @@
 name: tests-coverage
 
+on: pull-request
+
 jobs:
   build:
 

--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.11
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.11
     - name: Install dependencies

--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -18,16 +18,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest-cov
-        pip install -e .[test]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install hatch
     - name: Store EE token
       run: |
         python ./.github/scripts/make_ee_token.py
@@ -35,7 +33,7 @@ jobs:
         EE_TOKEN: ${{ secrets.EE_TOKEN }}
     - name: Test with pytest
       run: |
-        pytest --cov=./ --cov-report=xml
+        hatch run test:coverage --cov-report=xml
     - name: Upload to Codecov
       run: |
         bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,4 @@
-# This workflow sets up the Earth Engine token and runs all tests.
-
 name: tests
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,9 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
-        pip install -e .[test]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install hatch
     - name: Store EE token
       run: |
         python ./.github/scripts/make_ee_token.py
@@ -35,4 +33,4 @@ jobs:
         EE_TOKEN: ${{ secrets.EE_TOKEN }}
     - name: Test with pytest
       run: |
-        pytest .
+        hatch run test:all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: tests
 
+on: push
+
 jobs:
   build:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,8 +12,8 @@ Setup
 
         git clone https://github.com/{username}/wxee
         cd wxee
-        pip install -e .[dev]
-        pre-commit install
+        pip install hatch
+        hatch run -e test pre-commit install
 
 #. Create a new feature branch.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: GIS",
     "Typing :: Typed",
 ]
@@ -38,52 +39,14 @@ dependencies = [
     "xarray",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "black",
-    "hatch",
-    "hvplot",
-    "isort",
-    "matplotlib",
-    "mock",
-    "mypy",
-    "nbsphinx",
-    "pre-commit",
-    "pytest",
-    "pytest-cov",
-    "requests_mock",
-    "sphinx",
-    "sphinx_rtd_theme",
-    "netcdf4",
-    "plotly>=5.2.2",
-]
-doc = [
-    "nbsphinx",
-    "sphinx",
-    "sphinx_rtd_theme",
-]
-test = [
-    "netcdf4",
-    "plotly>=5.2.2",
-    "hvplot",
-    "matplotlib",
-    "mock",
-    "pytest",
-    "pytest-cov",
-    "requests_mock",
-]
-
 [project.urls]
 Homepage = "https://github.com/aazuspan/wxee"
 
 [tool.hatch.version]
 path = "wxee/__init__.py"
 
-
 [tool.hatch.build.targets.sdist]
-include = [
-    "/wxee",
-]
+include = ["/wxee"]
 
 [tool.hatch.envs.docs]
 dependences = [
@@ -96,9 +59,9 @@ dependences = [
 build = "sphinx-build -b html docs docs/_build/html"
 view = "python -m webbrowser -t docs/_build/html/index.html"
 
-
 [tool.hatch.envs.test]
 dependencies = [
+    "pre-commit",
     "netcdf4",
     "plotly>=5.2.2",
     "hvplot",
@@ -112,7 +75,7 @@ dependencies = [
 [tool.hatch.envs.test.scripts]
 all = "pytest . {args}"
 local = "pytest . -m 'not ee' {args}"
-coverage = "pytest . --cov=wxee --cov-report=html {args}"
+coverage = "pytest . --cov=wxee {args}"
 view-coverage = "python -m webbrowser -t htmlcov/index.html"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This PR would simplify the `pyproject.toml` and CI workflows by removing the optional dependencies in favor of using Hatch to manage everything.

Previously, dev, doc, and test dependency groups were specified in `pyproject.toml` to allow workflows like `pip install -e .[dev]`. However, this required managing the same list of dependencies in two places and no longer fits the suggested developer workflow of using Hatch for everything.

With the new changes, developers let Hatch manage all the needed dependencies using Hatch scripts, as outlined in the updated `contributing.rst`.

Unrelatedly, this PR also updates the CI to run on all branches and adds `3.11` to CI tests.