### PR TITLE
fix: use enum.member

### DIFF
--- a/wxee/interpolation.py
+++ b/wxee/interpolation.py
@@ -31,14 +31,13 @@ def cubic(
         a0.multiply(mu).multiply(mu2).add(a1.multiply(mu2)).add(a2.multiply(mu)).add(a3)
     )
 
+# This is a trick to maintain backward compatibility for Python version <3.11
+# https://stackoverflow.com/questions/40338652/how-to-define-enum-values-that-are-functions
+callable_member = partial if sys.version_info < (3, 11) else enum.member
 
 class InterpolationMethodEnum(ParamEnum):
     """Parameters defining interpolation methods"""
 
-    # This is a trick to maintain backward compatibility for Python version <3.11
-    # https://stackoverflow.com/questions/40338652/how-to-define-enum-values-that-are-functions
-    callable_member = partial if sys.version_info < (3, 11) else enum.member
-
-    nearest = callable_member(partial(nearest))
-    linear = callable_member(partial(linear))
-    cubic = callable_member(partial(cubic))
+    nearest = callable_member(nearest)
+    linear = callable_member(linear)
+    cubic = callable_member(cubic)

--- a/wxee/interpolation.py
+++ b/wxee/interpolation.py
@@ -1,5 +1,6 @@
-import functools
+from functools import partial
 import enum
+import sys
 
 import ee  # type: ignore
 
@@ -34,6 +35,10 @@ def cubic(
 class InterpolationMethodEnum(ParamEnum):
     """Parameters defining interpolation methods"""
 
-    nearest = enum.member(functools.partial(nearest))
-    linear = enum.member(functools.partial(linear))
-    cubic = enum.member(functools.partial(cubic))
+    # This is a trick to maintain backward compatibility for Python version <3.11
+    # https://stackoverflow.com/questions/40338652/how-to-define-enum-values-that-are-functions
+    callable_member = partial if sys.version_info < (3, 11) else enum.member
+
+    nearest = callable_member(partial(nearest))
+    linear = callable_member(partial(linear))
+    cubic = callable_member(partial(cubic))

--- a/wxee/interpolation.py
+++ b/wxee/interpolation.py
@@ -31,9 +31,11 @@ def cubic(
         a0.multiply(mu).multiply(mu2).add(a1.multiply(mu2)).add(a2.multiply(mu)).add(a3)
     )
 
+
 # This is a trick to maintain backward compatibility for Python version <3.11
 # https://stackoverflow.com/questions/40338652/how-to-define-enum-values-that-are-functions
-callable_member = partial if sys.version_info < (3, 11) else enum.member
+callable_member = partial if sys.version_info < (3, 11) else enum.member  # type: ignore
+
 
 class InterpolationMethodEnum(ParamEnum):
     """Parameters defining interpolation methods"""

--- a/wxee/interpolation.py
+++ b/wxee/interpolation.py
@@ -1,4 +1,5 @@
 import functools
+import enum
 
 import ee  # type: ignore
 
@@ -33,6 +34,6 @@ def cubic(
 class InterpolationMethodEnum(ParamEnum):
     """Parameters defining interpolation methods"""
 
-    nearest = functools.partial(nearest)
-    linear = functools.partial(linear)
-    cubic = functools.partial(cubic)
+    nearest = enum.member(functools.partial(nearest))
+    linear = enum.member(functools.partial(linear))
+    cubic = enum.member(functools.partial(cubic))


### PR DESCRIPTION
Fix #80 

As suggested by the deprecation warning i wrapped the partial call into an enum.member. My understanding of the documentation is that it avoids bugs with self being implicitely ingected in the partial calls. by doing this I should maintain compatibility with the previous version of python and avoid the error with Python 3.13. 