### PR TITLE
Remove deprecated `path` argument

### DIFF
--- a/wxee/collection.py
+++ b/wxee/collection.py
@@ -1,5 +1,4 @@
 import tempfile
-import warnings
 from typing import List, Optional
 
 import ee  # type: ignore
@@ -59,7 +58,7 @@ class ImageCollection:
 
     def to_xarray(
         self,
-        path: Optional[str] = None,
+        *,
         region: Optional[ee.Geometry] = None,
         scale: Optional[int] = None,
         crs: str = "EPSG:4326",
@@ -128,14 +127,6 @@ class ImageCollection:
             )
 
             ds = _dataset_from_files(files, masked, nodata)
-
-        if path:
-            msg = (
-                "The path argument is deprecated and will be removed in a future "
-                "release. Use the `xarray.Dataset.to_netcdf` method instead."
-            )
-            warnings.warn(category=DeprecationWarning, message=msg)
-            ds.to_netcdf(path, mode="w")
 
         return ds
 

--- a/wxee/image.py
+++ b/wxee/image.py
@@ -27,7 +27,7 @@ class Image:
 
     def to_xarray(
         self,
-        path: Optional[str] = None,
+        *,
         region: Optional[ee.Geometry] = None,
         scale: Optional[int] = None,
         crs: str = "EPSG:4326",
@@ -88,14 +88,6 @@ class Image:
             )
 
             ds = _dataset_from_files(files, masked, nodata)
-
-        if path:
-            msg = (
-                "The path argument is deprecated and will be removed in a future "
-                "release. Use the `xarray.Dataset.to_netcdf` method instead."
-            )
-            warnings.warn(category=DeprecationWarning, message=msg)
-            ds.to_netcdf(path, mode="w")
 
         return ds
 

--- a/wxee/interpolation.py
+++ b/wxee/interpolation.py
@@ -34,7 +34,7 @@ def cubic(
 
 # This is a trick to maintain backward compatibility for Python version <3.11
 # https://stackoverflow.com/questions/40338652/how-to-define-enum-values-that-are-functions
-callable_member = partial if sys.version_info < (3, 11) else enum.member  # type: ignore
+callable_member = partial if sys.version_info < (3, 11) else enum.member  # noqa
 
 
 class InterpolationMethodEnum(ParamEnum):


### PR DESCRIPTION
Using `path` was a shortcut for writing directly to NetCDF that's been deprecated for almost two years. Users can call the `to_netcdf` method of the returned object instead.

Since `path` was the first positional argument, removing it will change the order of the remaining `to_xarray` arguments, so I'm changing them all to keyword-only at the same time. This will be a breaking change for anyone who was calling the method with positional arguments, but I suspect that this is a rare use case since you would need to explicitly pass `None` as the first argument to avoid the deprecation warning.